### PR TITLE
feat: Add separate routes for finding category by ID and name.

### DIFF
--- a/src/category/category.controller.ts
+++ b/src/category/category.controller.ts
@@ -34,8 +34,13 @@ export class CategoryController {
   }
 
   @Get(':id')
-  findOne(@Param('id', ParseIntPipe) id: number): Promise<Category> {
-    return this.categoryService.findById(+id);
+  async findById(@Param('id', ParseIntPipe) id: number): Promise<Category> {
+    return await this.categoryService.findById(+id);
+  }
+
+  @Get(':name')
+  async findByName(@Param('name') name: string): Promise<Category> {
+    return await this.categoryService.findByName(name);
   }
 
   @Patch(':id')

--- a/src/category/category.service.ts
+++ b/src/category/category.service.ts
@@ -33,31 +33,51 @@ export class CategoryService {
   }
 
   async findAll(): Promise<Category[]> {
-    return await this.catRepo.find();
+    const category = await this.catRepo
+      .createQueryBuilder('category')
+      .select(['category.id', 'category.name', 'category.description'])
+      .getMany();
+
+    return category;
   }
 
   async findById(id: number): Promise<Category> {
-    const category = await this.catRepo.findOneBy({ id });
+    const category = await this.catRepo
+      .createQueryBuilder('category')
+      .select(['category.id', 'category.name', 'category.description'])
+      .where('category.id = :id', { id })
+      .getRawOne();
+
     if (!category) {
       throw new NotFoundException(`Category with id ${id} not found`);
     }
     return category;
   }
 
-  async findByName(catName: string): Promise<Category> {
-    const category = await this.catRepo.findOne({
-      where: { name: catName.toUpperCase() },
-    });
- 
-    return;
+  async findByName(name: string): Promise<Category> {
+    const categoryName = name.toUpperCase();
+    const category = await this.catRepo
+      .createQueryBuilder('category')
+      .select(['category.id', 'category.name', 'category.description'])
+      .where('category.name = :name', { name: categoryName })
+      .getRawOne();
+
+    if (!category) {
+      throw new NotFoundException(`Category with name ${name} not found`);
+    }
+
+    return category;
   }
 
-  async update(id: number, updateCategoryDto: UpdateCategoryDto):Promise<Category> {  
-    const updatedCategory = await this.findById( id );
+  async update(
+    id: number,
+    updateCategoryDto: UpdateCategoryDto,
+  ): Promise<Category> {
+    const updatedCategory = await this.findById(id);
 
-     await this.catRepo.update(id, updateCategoryDto);
+    await this.catRepo.update(id, updateCategoryDto);
 
-     return updatedCategory; 
+    return updatedCategory;
   }
 
   async remove(id: number): Promise<void> {


### PR DESCRIPTION
- Removed the previous single route findOne, which handled both cases.
- The findById route handle requests to retrieve a category by its ID.
- The findByName route handle requests to retrieve a category by its name.